### PR TITLE
Use the SVG renderer

### DIFF
--- a/vega-lite/index.js
+++ b/vega-lite/index.js
@@ -1,7 +1,12 @@
 define(["vega@3/build/vega.min.js", "vega-lite@2/build/vega-lite.min.js"], function(Vega, VegaLite) {
-  return function vegalite(spec) {
+  return function vegalite(spec, options) {
     var div = document.createElement("div");
-    var view = new Vega.View(Vega.parse(VegaLite.compile(spec).spec));
-    return view.initialize(div).renderer("svg").runAsync().then(function() { return div; });
+    var view = new Vega.View(Vega.parse(VegaLite.compile(spec).spec)).initialize(div);
+
+    if (options && options.renderer) {
+      view = view.renderer(options.renderer);
+    }
+
+    return view.runAsync().then(function() { return div; });
   };
 });

--- a/vega-lite/index.js
+++ b/vega-lite/index.js
@@ -2,6 +2,6 @@ define(["vega@3/build/vega.min.js", "vega-lite@2/build/vega-lite.min.js"], funct
   return function vegalite(spec) {
     var div = document.createElement("div");
     var view = new Vega.View(Vega.parse(VegaLite.compile(spec).spec));
-    return view.initialize(div).runAsync().then(function() { return div; });
+    return view.initialize(div).renderer("svg").runAsync().then(function() { return div; });
   };
 });

--- a/vega/index.js
+++ b/vega/index.js
@@ -2,6 +2,6 @@ define(["vega@3/build/vega.min.js"], function(Vega) {
   return function vega(spec) {
     var div = document.createElement("div");
     var view = new Vega.View(Vega.parse(spec));
-    return view.initialize(div).runAsync().then(function() { return div; });
+    return view.initialize(div).renderer("svg").runAsync().then(function() { return div; });
   };
 });

--- a/vega/index.js
+++ b/vega/index.js
@@ -1,7 +1,12 @@
 define(["vega@3/build/vega.min.js"], function(Vega) {
-  return function vega(spec) {
+  return function vega(spec, options) {
     var div = document.createElement("div");
-    var view = new Vega.View(Vega.parse(spec));
-    return view.initialize(div).renderer("svg").runAsync().then(function() { return div; });
+    var view = new Vega.View(Vega.parse(spec)).initialize(div);
+
+    if (options && options.renderer) {
+      view = view.renderer(options.renderer);
+    }
+
+    return view.runAsync().then(function() { return div; });
   };
 });


### PR DESCRIPTION
The default otherwise is `"canvas"`, but it feels like SVG would be more appropriate for most Observable usage.

This could be opt-in via either yet another module or duplicating this into `svg.js` and using longer `require` syntax from a notebook:

```javascript
vegalite = require("@obserablehq/vega-lite/svg.js")
```